### PR TITLE
Allow for swiping right even if a leading action does not exist

### DIFF
--- a/src/SwipeableListItem.js
+++ b/src/SwipeableListItem.js
@@ -522,7 +522,6 @@ class SwipeableListItem extends PureComponent {
       switch (octant) {
         case 0:
           if (
-            this.leadingActionsElement !== null &&
             horizontalDistance > this.dragHorizontalDirectionThreshold
           ) {
             this.dragDirection = DragDirection.RIGHT;
@@ -537,7 +536,6 @@ class SwipeableListItem extends PureComponent {
           break;
         case 4:
           if (
-            this.trailingActionsElement !== null &&
             horizontalDistance > this.dragHorizontalDirectionThreshold
           ) {
             this.dragDirection = DragDirection.LEFT;


### PR DESCRIPTION
In cases where only "trailing" actions exist for an item, it appears that the item can be put into such a state that the trailing action cannot be closed. I have some trouble reproducing this state, since logging or using a debugger affects the timing of it, preventing the bug from occurring, but I attached a video of the issue occurring below. The bug first appears at 12 seconds.

When swiping right to close an item, it often still has the `dragDirection` value of 3 (left), since that is what was used to open the element, this is likely incorrect, but produces the correct result. In the case where the bug appears, the `dragDirection` is changed to 5 (unknown), because it cannot be set to 4 (right), because no `leadingActionsElement` exists. While this PR doesn't resolve the problem of the `dragDirection` incorrectly being set to left, it allows the dragDirection to be right, even without a leading element, which allows the item to close the action.

I'm not entirely sure what effect this has on all other use cases, so maybe you can provide some insight into why these conditions exist in the first place. If this isn't an appropriate fix, let me know if you have a better recommendation for a fix. 

https://user-images.githubusercontent.com/894797/110275879-30c1f300-7f8f-11eb-8297-af3bbbc87462.mov