### PR TITLE
Fix closing opened actions when specific gesture is made

### DIFF
--- a/src/SwipeableListItem.js
+++ b/src/SwipeableListItem.js
@@ -460,6 +460,11 @@ class SwipeableListItem extends PureComponent {
   };
 
   handleDragEnd = () => {
+    if (this.requestedAnimationFrame) {
+      cancelAnimationFrame(this.requestedAnimationFrame);
+      this.requestedAnimationFrame = null;
+    }
+
     if (this.isSwiping()) {
       const { leadingFullSwipe, trailingFullSwipe, triggerAction } = this.state;
       const { onSwipeEnd } = this.props;
@@ -623,6 +628,11 @@ class SwipeableListItem extends PureComponent {
         this.trailingActionsOpened =
           Math.abs(this.left) > this.trailingActionsWidth;
         this.leadingActionsOpened = false;
+        console.log({
+          trailingActionsOpened: this.trailingActionsOpened,
+          left: this.left,
+          width: this.trailingActionsWidth,
+        });
       }
     }
 

--- a/src/SwipeableListItem.js
+++ b/src/SwipeableListItem.js
@@ -628,11 +628,6 @@ class SwipeableListItem extends PureComponent {
         this.trailingActionsOpened =
           Math.abs(this.left) > this.trailingActionsWidth;
         this.leadingActionsOpened = false;
-        console.log({
-          trailingActionsOpened: this.trailingActionsOpened,
-          left: this.left,
-          width: this.trailingActionsWidth,
-        });
       }
     }
 


### PR DESCRIPTION
If swipe is made quite fast sometimes `updatePosition` is called after `dragEnd` event. That breaks state of `trailingActionsOpened` and `dragStart` does not work anymore.

Added cancelling animation frame on `dragEnd` so that no more `updatePosition` is called.

Closes #2 