### PR TITLE
Update SwipeableListItemProps

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -171,7 +171,7 @@ interface SwipeableListItemProps {
   /**
    * Fired every time swipe progress changes. The reported `progress` value is always an integer in range 0 to 100 inclusive.
    */
-  onSwipeProgress?: () => void;
+  onSwipeProgress?: (progress:number) => void;
   /**
    * Fired after swipe has started (after drag gesture passes the `swipeStartThreshold` distance in pixels).
    */
@@ -206,6 +206,7 @@ interface SwipeableListItemProps {
    * `TrailingActions` component. See `TrailingActions`.
    */
   trailingActions?: ReactNode;
+  className?: string;
 }
 
 export class SwipeableListItem extends PureComponent<SwipeableListItemProps> {}


### PR DESCRIPTION
1. `onSwipeProgress`: The README lists `progress` as the prop being passed to the callback, but the type does not include the parameter, which causes a Typescript error.
![Screen Shot 2022-01-31 at 8 22 05 PM](https://user-images.githubusercontent.com/5953554/151912597-3201d094-4cf1-4242-a19e-82e2dc401f83.png)
![Screen Shot 2022-01-31 at 8 23 31 PM](https://user-images.githubusercontent.com/5953554/151912606-ac278a00-7d8c-4f48-ae61-d4c75fec1bd1.png)

2. `className`: This code block shows `className` as an accepted prop (https://github.com/marekrozmus/react-swipeable-list/blob/main/src/SwipeableListItem.js#L768-L773), but needs to be added to the types to avoid a TS error

![Screen Shot 2022-01-31 at 8 29 41 PM](https://user-images.githubusercontent.com/5953554/151912959-f0c5c303-dfde-421c-a82a-c200f77c971f.png)

