### PR TITLE
Allow `null` values in trailing and leading actions

### DIFF
--- a/src/LeadingActions.js
+++ b/src/LeadingActions.js
@@ -8,12 +8,15 @@ const LeadingActions = ({ children }) => {
   }
 
   if (Array.isArray(children)) {
-    return React.Children.map(children, (child, index) =>
-      React.cloneElement(child, {
+    return React.Children.map(children, (child, index) => {
+      if (!React.isValidElement(child)) {
+        return child;
+      }
+      return React.cloneElement(child, {
         leading: true,
         main: index === 0,
       })
-    );
+    });
   }
 
   return React.cloneElement(children, {

--- a/src/TrailingActions.js
+++ b/src/TrailingActions.js
@@ -8,12 +8,15 @@ const TrailingActions = ({ children }) => {
   }
 
   if (Array.isArray(children)) {
-    return React.Children.map(children, (child, index) =>
-      React.cloneElement(child, {
+    return React.Children.map(children, (child, index) => {
+      if (!React.isValidElement(child)) {
+        return child;
+      }
+      return React.cloneElement(child, {
         main: index === children.length - 1,
         trailing: true,
       })
-    );
+    });
   }
 
   return React.cloneElement(children, {


### PR DESCRIPTION
# What

This pull requests adds a `React.isValidElement` check right before the trailing and leading elements are cloned.

# Why?

Without this, any child that is passed will automatically be cloned, even if it is not a valid React element. If that is the case, a fatal error will be thrown, breaking the entire application.

This pull request fixes that by simply returning the child as-is if it is not a React element.

# Use cases?

I came across this issue because I want to conditionally show certain actions. Right now, it's impossible to do it like this:

```tsx
<LeadingActions>
    {someCondition ? (
        <SwipeAction
            destructive={true}
            onClick={() => {
                doSomething()
            }}>
            Do something
        </SwipeAction>
    ) : null}
    {anotherCondition ? (
        <SwipeAction
            destructive={true}
            onClick={() => {
                doAnotherThing()
            }}>
            Do another thing
        </SwipeAction>
    ) : null}
</LeadingActions>
```

If ONE of these conditions is false, I would expect the other element to still be rendered. This is not the case, because the returned `null` is seen as a child, which is subsequently cloned (causing an error).